### PR TITLE
FUNC fix in parser and code generation

### DIFF
--- a/src/backend/CodeGen.cs
+++ b/src/backend/CodeGen.cs
@@ -86,6 +86,9 @@ public class CodeGen{
         if(IR.getOp() == IrOp.LABEL){
             return IR.getDest() + ':';
         }
+        if(IR.getOp() == IrOp.FUNC) {
+            return IR.getDest() + ':';
+        }
         // MOD
         if(IR.getOp() == IrOp.NOT){
             return "MVN " + IROOI.getDest() + ", " + IROOI.getSrc1();

--- a/src/grammar/TCDSwift.ATG
+++ b/src/grammar/TCDSwift.ATG
@@ -903,7 +903,7 @@ TCDSwift
 
                                   foreach(var func in functionDecls.Values)
                                   {
-                                      program.Add(new IRTuple(IrOp.LABEL, func._label));
+                                      program.Add(new IRTuple(IrOp.FUNC, func._label));
                                       foreach(var inst in func._codeblock)
                                       {
                                           program.Add(inst);


### PR DESCRIPTION
@jhd @IanConnolly @Shayanzadeh @FintanH 

This pull request is to fix the bug where there is a `FUNC` tuple in the IR Tuple spec but it was not implemented in the parser or in the code generation phase. I need the `FUNC` tuple in the SSA code optimisation phase.

There is no different between the data contained inside either
```
{LABEL, exampleFunction}
```
or 
```
{FUNC, exampleFunction}
```
they both contain labels to the the function pointer. The `FUNC` tuple just gives me an indication that the label is at the label at the start of function as opposed to any other kind of label.